### PR TITLE
repair broken tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.3-8 MINOR: Restore unit tests that were disabled in 0.3-7 and 0.3-5
+
 0.3-7: MINOR: Disable a test that had begun failing on CRAN due to an update to system netCDF library updates on some operating systems.
 
 0.3-5: MINOR: Update maintainer, test suite, and documentation. On the Debian OS, one of the tests returns some unexpected values, and is partially skipped.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ncdf4.helpers
 Version: 0.3-8
-Date: 2025-04-15
+Date: 2025-05-30
 Title: Helper Functions for Use with the 'ncdf4' Package
 Authors@R: c(
     person("David", "Bronaugh", email = "bronaugh@uvic.ca", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ncdf4.helpers
-Version: 0.3-7
-Date: 2025-03-06
+Version: 0.3-8
+Date: 2025-04-15
 Title: Helper Functions for Use with the 'ncdf4' Package
 Authors@R: c(
     person("David", "Bronaugh", email = "bronaugh@uvic.ca", role = "aut"),

--- a/R/helpers.r
+++ b/R/helpers.r
@@ -308,6 +308,8 @@ nc.conform.data <- function(f.input, f.output, v.input, v.output, dat.input, all
 #' 
 #' Attributes can also be renamed at the destination using \code{rename.mapping}, a named vector of strings in which the name of the attribute to be renamed is the name, and the attribute's new name is the value.
 #'
+#' Note: Depending on which version of the netCDF4 system library you have installed, copying a _FillValue attribute may raise an error.
+#'
 #' @param f.src The source file (an object of class \code{ncdf4})
 #' @param v.src The source variable: a string naming a variable in a file or an object of class \code{ncvar4}.
 #' @param f.dest The destination file (an object of class \code{ncdf4})

--- a/tests/testthat/test-file-functions.R
+++ b/tests/testthat/test-file-functions.R
@@ -140,7 +140,6 @@ test_that("a subset of data can be read", {
 })
 
 test_that("data can be written to a netCDF file", {
-	skip("Test update in progress")
 	filename <- tempfile()
 	f.in <- nc_open("test1.nc")
 	dat <- nc.get.var.subset.by.axes(f.in, "tasmax", list(X=1:4, Y=c(1, 3, 5)))
@@ -151,7 +150,7 @@ test_that("data can be written to a netCDF file", {
 	f.out <- nc_create(filename, var.list)
 	nc.copy.atts(f.in, "rlat", f.out, "rlat")
 	nc.copy.atts(f.in, "rlon", f.out, "rlon")
-	nc.copy.atts(f.in, "tasmax", f.out, "tasmax")
+	nc.copy.atts(f.in, "tasmax", f.out, "tasmax", c("_FillValue"))
 	dat.permuted <- nc.conform.data(f.in, f.out, "tasmax", "tasmax", dat, allow.dim.subsets=TRUE)
 	nc.put.var.subset.by.axes(f.out, "tasmax", dat.permuted, list())
 	nc_sync(f.out)

--- a/tests/testthat/test-file-functions.R
+++ b/tests/testthat/test-file-functions.R
@@ -29,7 +29,6 @@ test_that("time series can be retrieved from file", {
 
 
 test_that("grid mappings are read and applied", {
-	skip("Test update in progress")
 	f <- nc_open("test1.nc", readunlim=FALSE)
 	proj4.string <- "+proj=ob_tran +o_proj=longlat +lon_0=-97 +o_lat_p=42.5 +a=1 +to_meter=0.0174532925199 +no_defs"
 	expect_equal(nc.get.proj4.string(f, "tasmax"), proj4.string)
@@ -40,24 +39,19 @@ test_that("grid mappings are read and applied", {
 	expect_equal(lat.dat[1,130], 59.1459007263184)
 	expect_equal(lat.dat[155,1], 12.3573160171509)
 	expect_equal(lat.dat[155,130], 59.1459159851074)
-	
-	
+		
 	lon.dat <- ncvar_get(f, "lon")
 	expect_equal(dim(lon.dat), c(155,130))
 	expect_equal(lon.dat[1,1], 232.930877685547)
 	expect_equal(lon.dat[1,130], 189.603073120117)
 	expect_equal(lon.dat[155,1], 293.069122314453)
 	expect_equal(lon.dat[155,130], 336.396881103516)
+	
 			
 	indices <- matrix(c(1, 155, 155, 1, 1, 1, 130, 130), nrow=4, ncol=2)
 	colnames(indices) <- c("x", "y")
 	
-	# The project() function in the proj4 r package returns unexpected values
-	# on these inputs on Debian systems.
-	# Run on Ubuntu, Windows, Fedora, CentOS, and Mac, the tests behave as expected.
-	# Accordingly, the last part of this test is skipped on Debian systems.
-	skip_if(grepl("Debian", Sys.info()["version"]), message="proj4 behaves unexpectedly on a Debian system")
-	projected.data <- list(x=f$dim$rlon$vals[indices[,"x"]], y=f$dim$rlat$vals[indices[,"y"]])
+	projected.data <- list(x=f$dim$rlon$vals[indices[,"x"]]* pi/180, y=f$dim$rlat$vals[indices[,"y"]]* pi/180)
 			
 	latlon.data <- project(projected.data, proj4.string, ellps.default=NA, inverse=TRUE)
 	expect_equal((latlon.data$x + 360) %% 360, lon.dat[indices], tolerance=1e-5)


### PR DESCRIPTION
This PR fixes two tests which broke due to changes in the ways underlying system libraries work:

1. A test of reprojecting coordinates from one system to another stopped working when the proj4 library no longer did an automatic units conversion; the units have to be manually fixed. @QSparks tracked this down
2. A test of writing to a netCDF file began failing with system library netCDF 4.9.1 . As of this version of the netCDF system library, if you change a variable's `_FillValue `by assigning a value to the attribute with the same name, and then write to the variable, the write will crash.

Resolves #11 